### PR TITLE
New fire time

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,11 +1,11 @@
 {
-  "queueSize": 50,
+  "queueSize": 5000,
   "errorHandling": true,
   "events": {
     "linkClicks": true,
     "clicks": true,
     "pageviews": true,
-    "mousemoves": false,
+    "mousemoves": true,
     "formSubmits": true,
     "keypress": true
   }

--- a/javascripts/tracker.js
+++ b/javascripts/tracker.js
@@ -127,7 +127,7 @@ module.exports = sendData;
 
 },{}],4:[function(require,module,exports){
 const createQueue = require('./queue');
-const queue = createQueue(50);
+const queue = createQueue(5000);
 
 const getEventData = (eType, e) => {
   const timestamp = Date.now(); // NEEDS TO REFLECT CLIENT TIME -- must fix
@@ -165,13 +165,14 @@ const getEventData = (eType, e) => {
       };
     case 'form_submissions':
       const inputs = [...e.target.elements].filter(e => e.tagName === 'INPUT');
-      const data = {
-        eType,
-      };
+      const data = {};
 
       inputs.forEach(input => data[input.name] = input.value);
 
-      return data;
+      return {
+        eType,
+        data,
+      };
     case 'pageviews': {
       return {
         eType,
@@ -193,9 +194,9 @@ document.addEventListener('DOMContentLoaded', function(event) {
   let mousePos;
   let prevMousePos;
 
-  const events = {"linkClicks":true,"clicks":true,"pageviews":true,"mousemoves":false,"formSubmits":true,"keypress":true};
+  const events = {"linkClicks":true,"clicks":true,"pageviews":true,"mousemoves":true,"formSubmits":true,"keypress":true};
 
-  document.addEventListener('beforeunload', event => {
+  window.addEventListener('beforeunload', event => {
     queue.flush();
   });
 

--- a/javascripts/tracker.js
+++ b/javascripts/tracker.js
@@ -157,13 +157,13 @@ const getEventData = (eType, e) => {
         y: e.y,
         timestamp,
       };
-    case 'key_press':
+    case 'key_presses':
       return {
         eType,
         key: e.key,
         timestamp,
       };
-    case 'form_submission':
+    case 'form_submissions':
       const inputs = [...e.target.elements].filter(e => e.tagName === 'INPUT');
       const data = {
         eType,
@@ -172,7 +172,7 @@ const getEventData = (eType, e) => {
       inputs.forEach(input => data[input.name] = input.value);
 
       return data;
-    case 'pageview': {
+    case 'pageviews': {
       return {
         eType,
         url: window.location.href,
@@ -201,7 +201,7 @@ document.addEventListener('DOMContentLoaded', function(event) {
 
   if (events.pageviews) {
     (() => {
-      addToQueue('pageview');
+      addToQueue('pageviews');
     })();
   }
 
@@ -249,13 +249,13 @@ document.addEventListener('DOMContentLoaded', function(event) {
 
   if (events.keypress) {
     document.addEventListener('keypress', (event) => {
-      addToQueue('key_press', event);
+      addToQueue('key_presses', event);
     });
   }
 
   if (events.formSubmits) {
     document.addEventListener('submit', (event) => {
-      addToQueue('form_submission', event);
+      addToQueue('form_submissions', event);
     });
   }
 });

--- a/javascripts/tracker.js
+++ b/javascripts/tracker.js
@@ -82,7 +82,6 @@ function createQueue(maxSize) {
 
     checkMax () {
       if (size >= max) {
-        console.log('flushing!');
         this.flush();
       }
     },
@@ -120,7 +119,6 @@ const sendData = (url, json) => {
     .then(json => console.log(json))
     .catch(error => console.log(error));
   } else {
-    // const blob = new Blob([json], {type: 'application/json; charset=utf-8'});
     navigator.sendBeacon(url, json);
   }
 }
@@ -128,8 +126,6 @@ const sendData = (url, json) => {
 module.exports = sendData;
 
 },{}],4:[function(require,module,exports){
-// window.axios = require('axios');
-
 const createQueue = require('./queue');
 const queue = createQueue(50);
 
@@ -189,10 +185,6 @@ const getEventData = (eType, e) => {
   }
 }
 
-// const formatToJSON = (eType, e) => {
-//   return JSON.stringify(getEventData(eType, e));
-// }
-
 const addToQueue = (eType, e) => {
   queue.add(getEventData(eType, e));
 }
@@ -202,6 +194,10 @@ document.addEventListener('DOMContentLoaded', function(event) {
   let prevMousePos;
 
   const events = {"linkClicks":true,"clicks":true,"pageviews":true,"mousemoves":false,"formSubmits":true,"keypress":true};
+
+  document.addEventListener('beforeunload', event => {
+    queue.flush();
+  });
 
   if (events.pageviews) {
     (() => {
@@ -213,7 +209,6 @@ document.addEventListener('DOMContentLoaded', function(event) {
     document.addEventListener('click', function(event) {
       if (event.target.tagName === 'A') {
         addToQueue('link_clicks', event);
-        queue.flush();
       }
 
       addToQueue('clicks', event);
@@ -226,7 +221,6 @@ document.addEventListener('DOMContentLoaded', function(event) {
     document.addEventListener('click', function(event) {
       if (event.target.tagName === 'A') {
         addToQueue('link_clicks', event);
-        queue.flush();
       }
     });
   }
@@ -261,11 +255,7 @@ document.addEventListener('DOMContentLoaded', function(event) {
 
   if (events.formSubmits) {
     document.addEventListener('submit', (event) => {
-      event.preventDefault();
-
       addToQueue('form_submission', event);
-      queue.flush();
-      event.target.submit();
     });
   }
 });

--- a/src/queue.js
+++ b/src/queue.js
@@ -16,7 +16,6 @@ function createQueue(maxSize) {
 
     checkMax () {
       if (size >= max) {
-        console.log('flushing!');
         this.flush();
       }
     },

--- a/src/sendData.js
+++ b/src/sendData.js
@@ -12,7 +12,6 @@ const sendData = (url, json) => {
     .then(json => console.log(json))
     .catch(error => console.log(error));
   } else {
-    // const blob = new Blob([json], {type: 'application/json; charset=utf-8'});
     navigator.sendBeacon(url, json);
   }
 }

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -1,5 +1,3 @@
-// window.axios = require('axios');
-
 const createQueue = require('./queue');
 const queue = createQueue(process.env['queueSize']);
 
@@ -59,10 +57,6 @@ const getEventData = (eType, e) => {
   }
 }
 
-// const formatToJSON = (eType, e) => {
-//   return JSON.stringify(getEventData(eType, e));
-// }
-
 const addToQueue = (eType, e) => {
   queue.add(getEventData(eType, e));
 }
@@ -72,6 +66,10 @@ document.addEventListener('DOMContentLoaded', function(event) {
   let prevMousePos;
 
   const events = process.env['events'];
+
+  document.addEventListener('beforeunload', event => {
+    queue.flush();
+  });
 
   if (events.pageviews) {
     (() => {
@@ -83,7 +81,6 @@ document.addEventListener('DOMContentLoaded', function(event) {
     document.addEventListener('click', function(event) {
       if (event.target.tagName === 'A') {
         addToQueue('link_clicks', event);
-        queue.flush();
       }
 
       addToQueue('clicks', event);
@@ -96,7 +93,6 @@ document.addEventListener('DOMContentLoaded', function(event) {
     document.addEventListener('click', function(event) {
       if (event.target.tagName === 'A') {
         addToQueue('link_clicks', event);
-        queue.flush();
       }
     });
   }
@@ -131,11 +127,7 @@ document.addEventListener('DOMContentLoaded', function(event) {
 
   if (events.formSubmits) {
     document.addEventListener('submit', (event) => {
-      event.preventDefault();
-
       addToQueue('form_submission', event);
-      queue.flush();
-      event.target.submit();
     });
   }
 });

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -29,13 +29,13 @@ const getEventData = (eType, e) => {
         y: e.y,
         timestamp,
       };
-    case 'key_press':
+    case 'key_presses':
       return {
         eType,
         key: e.key,
         timestamp,
       };
-    case 'form_submission':
+    case 'form_submissions':
       const inputs = [...e.target.elements].filter(e => e.tagName === 'INPUT');
       const data = {
         eType,
@@ -44,7 +44,7 @@ const getEventData = (eType, e) => {
       inputs.forEach(input => data[input.name] = input.value);
 
       return data;
-    case 'pageview': {
+    case 'pageviews': {
       return {
         eType,
         url: window.location.href,
@@ -73,7 +73,7 @@ document.addEventListener('DOMContentLoaded', function(event) {
 
   if (events.pageviews) {
     (() => {
-      addToQueue('pageview');
+      addToQueue('pageviews');
     })();
   }
 
@@ -121,13 +121,13 @@ document.addEventListener('DOMContentLoaded', function(event) {
 
   if (events.keypress) {
     document.addEventListener('keypress', (event) => {
-      addToQueue('key_press', event);
+      addToQueue('key_presses', event);
     });
   }
 
   if (events.formSubmits) {
     document.addEventListener('submit', (event) => {
-      addToQueue('form_submission', event);
+      addToQueue('form_submissions', event);
     });
   }
 });

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -37,13 +37,14 @@ const getEventData = (eType, e) => {
       };
     case 'form_submissions':
       const inputs = [...e.target.elements].filter(e => e.tagName === 'INPUT');
-      const data = {
-        eType,
-      };
+      const data = {};
 
       inputs.forEach(input => data[input.name] = input.value);
 
-      return data;
+      return {
+        eType,
+        data,
+      };
     case 'pageviews': {
       return {
         eType,
@@ -67,7 +68,7 @@ document.addEventListener('DOMContentLoaded', function(event) {
 
   const events = process.env['events'];
 
-  document.addEventListener('beforeunload', event => {
+  window.addEventListener('beforeunload', event => {
     queue.flush();
   });
 


### PR DESCRIPTION
Fixed tracker so that it now flushes the queue on the `beforeunload` event as opposed to manually doing so whenever a user clicks on a link or a forum. It does mean that links that to take the user to a new page (i.e., ends with `#`) do not flush the queue, but that is _good_ thing in my opinion as they aren't actually leaving the page.